### PR TITLE
Fix thumb position not centered after react-native upgrade to 0.42+

### DIFF
--- a/lib/Slider.js
+++ b/lib/Slider.js
@@ -276,7 +276,7 @@ mainStyles.thumb,thumbStyle,_extends({
 
 transform:[
 {translateX:thumbLeft},
-{translateY:-(-trackSize.height+thumbSize.height)/2}]},
+{translateY:0}]},
 
 valueVisibleStyle)]}),
 

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -276,7 +276,7 @@ var Slider = React.createClass({
             {
               transform: [
                 { translateX: thumbLeft },
-                { translateY: -(-trackSize.height + thumbSize.height) / 2 }
+                { translateY: 0 }
               ],
               ...valueVisibleStyle
             }


### PR DESCRIPTION
**Before**

![image](https://cloud.githubusercontent.com/assets/619186/23764896/ea1c1a78-04dd-11e7-8818-7d9afe7ce43c.png)


**After (iOS)**

![image](https://cloud.githubusercontent.com/assets/619186/23764814/9ddcc4c8-04dd-11e7-8c99-aaa83b37a30a.png)

**After (Android)**

![image](https://cloud.githubusercontent.com/assets/619186/23764834/aa38645c-04dd-11e7-9cec-5a1ea45ea041.png)
